### PR TITLE
Remove GetMap service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ find_package(geographic_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/OrthoImage3D.msg"
-  "srv/GetMap.srv"
   DEPENDENCIES sensor_msgs geographic_msgs
  )
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gisnav_msgs</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Message definitions for GISNav ROS 2 package.</description>
   <author email="hmakelin@protonmail.com">Harri Makelin</author>
   <maintainer email="hmakelin@protonmail.com">Harri Makelin</maintainer>

--- a/srv/GetMap.srv
+++ b/srv/GetMap.srv
@@ -1,6 +1,0 @@
-# High-resolution orthoimage together with its associated elevation raster (DEM) in one atomic message
-geographic_msgs/BoundingBox bbox
-int16 height
-int16 width
----
-gisnav_msgs/OrthoImage3D image


### PR DESCRIPTION
The GetMap service is no longer needed by https://github.com/hmakelin/gisnav/pull/23. After further refactoring the DEM is handled completely inside MapNode and does not need to be requested by BaseNode (which will be renamed by the linked PR).

Updates version number to 0.2.0.